### PR TITLE
feature/daywork crud re

### DIFF
--- a/src/main/java/com/whatachad/app/api/Re_ScheduleCrudApi.java
+++ b/src/main/java/com/whatachad/app/api/Re_ScheduleCrudApi.java
@@ -1,0 +1,32 @@
+package com.whatachad.app.api;
+
+import com.whatachad.app.model.request.CreateDayworkRequestDto;
+import com.whatachad.app.model.request.Re_CreateDayworkRequestDto;
+import com.whatachad.app.model.response.CreateDayworkResponseDto;
+import com.whatachad.app.model.response.Re_CreateDayworkResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Tag(name = "Re_Schedule API", description = "스케줄 관련 기능")
+@RequestMapping("/v1/re_schedule")
+public interface Re_ScheduleCrudApi {
+    @Operation(summary = "일정(daywork) 등록",
+            description = " daywork 등록 시 기존에 Schedule이 존재하지 않으면 새로 생성하여 저장한다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK",
+                    content = @Content(schema = @Schema(implementation = Re_CreateDayworkResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "Bad Request"),
+            @ApiResponse(responseCode = "405", description = "Method Not Allowed")
+    })
+    @PostMapping("/{YYYYMM}/dayworks/{DD}")
+    public ResponseEntity<Re_CreateDayworkResponseDto> registerDaywork(@RequestBody Re_CreateDayworkRequestDto requestDto, @PathVariable("YYYYMM") String yearAndMonth, @PathVariable("DD") Integer date);
+}

--- a/src/main/java/com/whatachad/app/api/Re_ScheduleCrudApi.java
+++ b/src/main/java/com/whatachad/app/api/Re_ScheduleCrudApi.java
@@ -1,9 +1,10 @@
 package com.whatachad.app.api;
 
-import com.whatachad.app.model.request.CreateDayworkRequestDto;
 import com.whatachad.app.model.request.Re_CreateDayworkRequestDto;
-import com.whatachad.app.model.response.CreateDayworkResponseDto;
+import com.whatachad.app.model.request.Re_UpdateDayworkRequestDto;
+import com.whatachad.app.model.request.UpdateDayworkRequestDto;
 import com.whatachad.app.model.response.Re_CreateDayworkResponseDto;
+import com.whatachad.app.model.response.Re_UpdateDayworkResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -11,10 +12,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Re_Schedule API", description = "스케줄 관련 기능")
 @RequestMapping("/v1/re_schedule")
@@ -29,4 +27,16 @@ public interface Re_ScheduleCrudApi {
     })
     @PostMapping("/{YYYYMM}/dayworks/{DD}")
     public ResponseEntity<Re_CreateDayworkResponseDto> registerDaywork(@RequestBody Re_CreateDayworkRequestDto requestDto, @PathVariable("YYYYMM") String yearAndMonth, @PathVariable("DD") Integer date);
+
+    @Operation(summary = "일정(daywork) 수정",
+            description = "일정의 title, priority, status, hour, minute 를 수정할 수 있다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK",
+                    content = @Content(schema = @Schema(implementation = Re_UpdateDayworkResponseDto.class))),
+            @ApiResponse(responseCode = "400", description = "Bad Request"),
+            @ApiResponse(responseCode = "405", description = "Method Not Allowed")
+    })
+    @PutMapping("/{YYYYMM}/dayworks/{DD}/{dayworkId}")
+    public ResponseEntity<Re_UpdateDayworkResponseDto> editDaywork(@RequestBody Re_UpdateDayworkRequestDto requestDto, @PathVariable Long dayworkId);
+
 }

--- a/src/main/java/com/whatachad/app/api/Re_ScheduleCrudApi.java
+++ b/src/main/java/com/whatachad/app/api/Re_ScheduleCrudApi.java
@@ -39,4 +39,14 @@ public interface Re_ScheduleCrudApi {
     @PutMapping("/{YYYYMM}/dayworks/{DD}/{dayworkId}")
     public ResponseEntity<Re_UpdateDayworkResponseDto> editDaywork(@RequestBody Re_UpdateDayworkRequestDto requestDto, @PathVariable Long dayworkId);
 
+    @Operation(summary = "일정(daywork) 삭제",
+            description = "daywork_id를 이용해 일정을 삭제한다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "400", description = "Bad Request"),
+            @ApiResponse(responseCode = "405", description = "Method Not Allowed")
+    })
+    @DeleteMapping("/{YYYYMM}/dayworks/{DD}/{dayworkId}")
+    public void deleteDaywork(@PathVariable Long dayworkId);
+
 }

--- a/src/main/java/com/whatachad/app/controller/Re_ScheduleCrudController.java
+++ b/src/main/java/com/whatachad/app/controller/Re_ScheduleCrudController.java
@@ -56,4 +56,9 @@ public class Re_ScheduleCrudController implements Re_ScheduleCrudApi {
 
         return ResponseEntity.ok(dayworkMapper.toUpdateResponseDto(daywork));
     }
+
+    @Override
+    public void deleteDaywork(Long dayworkId) {
+        dayworkService.deleteDaywork(dayworkId);
+    }
 }

--- a/src/main/java/com/whatachad/app/controller/Re_ScheduleCrudController.java
+++ b/src/main/java/com/whatachad/app/controller/Re_ScheduleCrudController.java
@@ -9,8 +9,10 @@ import com.whatachad.app.model.dto.Re_DayworkDto;
 import com.whatachad.app.model.dto.Re_ScheduleDto;
 import com.whatachad.app.model.request.CreateDayworkRequestDto;
 import com.whatachad.app.model.request.Re_CreateDayworkRequestDto;
+import com.whatachad.app.model.request.Re_UpdateDayworkRequestDto;
 import com.whatachad.app.model.response.CreateDayworkResponseDto;
 import com.whatachad.app.model.response.Re_CreateDayworkResponseDto;
+import com.whatachad.app.model.response.Re_UpdateDayworkResponseDto;
 import com.whatachad.app.service.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,6 +31,8 @@ public class Re_ScheduleCrudController implements Re_ScheduleCrudApi {
     private final Re_DayworkMapperService dayworkMapper;
     private final Re_ScheduleService scheduleService;
     private final Re_DayScheduleService dayScheduleService;
+    private final Re_DayworkService dayworkService;
+
     /**
      * Daywork 관련
      * */
@@ -43,5 +47,13 @@ public class Re_ScheduleCrudController implements Re_ScheduleCrudApi {
         Re_Daywork daywork = dayScheduleService.createDaywork(dayworkDto, daySchedule.getId());
 
         return ResponseEntity.ok(dayworkMapper.toCreateResponseDto(daywork));
+    }
+
+    @Override
+    public ResponseEntity<Re_UpdateDayworkResponseDto> editDaywork(Re_UpdateDayworkRequestDto requestDto, Long dayworkId) {
+        Re_DayworkDto dayworkDto = dayworkMapper.toDayworkDto(requestDto);
+        Re_Daywork daywork = dayworkService.updateDaywork(dayworkDto, dayworkId);
+
+        return ResponseEntity.ok(dayworkMapper.toUpdateResponseDto(daywork));
     }
 }

--- a/src/main/java/com/whatachad/app/controller/Re_ScheduleCrudController.java
+++ b/src/main/java/com/whatachad/app/controller/Re_ScheduleCrudController.java
@@ -1,0 +1,47 @@
+package com.whatachad.app.controller;
+
+import com.whatachad.app.api.Re_ScheduleCrudApi;
+import com.whatachad.app.model.domain.Re_DaySchedule;
+import com.whatachad.app.model.domain.Re_Daywork;
+import com.whatachad.app.model.domain.Re_Schedule;
+import com.whatachad.app.model.dto.Re_DayScheduleDto;
+import com.whatachad.app.model.dto.Re_DayworkDto;
+import com.whatachad.app.model.dto.Re_ScheduleDto;
+import com.whatachad.app.model.request.CreateDayworkRequestDto;
+import com.whatachad.app.model.request.Re_CreateDayworkRequestDto;
+import com.whatachad.app.model.response.CreateDayworkResponseDto;
+import com.whatachad.app.model.response.Re_CreateDayworkResponseDto;
+import com.whatachad.app.service.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@CrossOrigin(origins = "*")
+@RequiredArgsConstructor
+public class Re_ScheduleCrudController implements Re_ScheduleCrudApi {
+
+    private final Re_ScheduleMapperService scheduleMapper;
+    private final Re_DayScheduleMapperService dayScheduleMapper;
+    private final Re_DayworkMapperService dayworkMapper;
+    private final Re_ScheduleService scheduleService;
+    private final Re_DayScheduleService dayScheduleService;
+    /**
+     * Daywork 관련
+     * */
+    @Override
+    public ResponseEntity<Re_CreateDayworkResponseDto> registerDaywork(Re_CreateDayworkRequestDto requestDto, String yearAndMonth, Integer date) {
+        Re_ScheduleDto scheduleDto = scheduleMapper.toScheduleDto(yearAndMonth);
+        Re_DayScheduleDto dayScheduleDto = dayScheduleMapper.toDayScheduleDto(date);
+        Re_DayworkDto dayworkDto = dayworkMapper.toDayworkDto(requestDto);
+
+        Re_Schedule schedule = scheduleService.getOrCreateSchedule(scheduleDto);
+        Re_DaySchedule daySchedule = scheduleService.getDaySchedule(dayScheduleDto, schedule.getId());
+        Re_Daywork daywork = dayScheduleService.createDaywork(dayworkDto, daySchedule.getId());
+
+        return ResponseEntity.ok(dayworkMapper.toCreateResponseDto(daywork));
+    }
+}

--- a/src/main/java/com/whatachad/app/model/domain/Re_Account.java
+++ b/src/main/java/com/whatachad/app/model/domain/Re_Account.java
@@ -1,0 +1,33 @@
+package com.whatachad.app.model.domain;
+
+import com.whatachad.app.type.AccountCategory;
+import com.whatachad.app.type.AccountType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Re_Account extends BaseTime{
+
+    @Id @GeneratedValue
+    @Column(name = "ACCOUNT_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "DAYSCHEDULE_ID")
+    private Re_DaySchedule daySchedule;
+
+    private String title;
+
+    private Integer cost;
+
+    @Enumerated(EnumType.STRING)
+    private AccountType type;
+
+    @Enumerated(EnumType.STRING)
+    private AccountCategory category;
+
+}

--- a/src/main/java/com/whatachad/app/model/domain/Re_Account.java
+++ b/src/main/java/com/whatachad/app/model/domain/Re_Account.java
@@ -30,4 +30,9 @@ public class Re_Account extends BaseTime{
     @Enumerated(EnumType.STRING)
     private AccountCategory category;
 
+    /* 연관관계 편의 메소드 */
+    public void addDaySchedule(Re_DaySchedule daySchedule) {
+        this.daySchedule = daySchedule;
+        daySchedule.getAccounts().add(this);
+    }
 }

--- a/src/main/java/com/whatachad/app/model/domain/Re_DaySchedule.java
+++ b/src/main/java/com/whatachad/app/model/domain/Re_DaySchedule.java
@@ -1,0 +1,27 @@
+package com.whatachad.app.model.domain;
+
+import com.whatachad.app.type.Workcheck;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Re_DaySchedule {
+
+    @Id @GeneratedValue
+    @Column(name = "DAYSCHEDULE_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "SCHEDULE_ID")
+    private Re_Schedule schedule;
+
+    private Integer date;
+
+    @Enumerated(EnumType.STRING)
+    private Workcheck totalDayworkStatus;
+
+}

--- a/src/main/java/com/whatachad/app/model/domain/Re_DaySchedule.java
+++ b/src/main/java/com/whatachad/app/model/domain/Re_DaySchedule.java
@@ -4,6 +4,9 @@ import com.whatachad.app.type.Workcheck;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @Builder
 @NoArgsConstructor
@@ -24,4 +27,15 @@ public class Re_DaySchedule {
     @Enumerated(EnumType.STRING)
     private Workcheck totalDayworkStatus;
 
+    @OneToMany(mappedBy = "daySchedule")
+    private List<Re_Daywork> dayworks = new ArrayList<>();
+
+    @OneToMany(mappedBy = "daySchedule")
+    private List<Re_Account> accounts = new ArrayList<>();
+
+    /* 연관관계 편의 메소드 */
+    public void addSchedule(Re_Schedule schedule) {
+        this.schedule = schedule;
+        schedule.getDays().add(this);
+    }
 }

--- a/src/main/java/com/whatachad/app/model/domain/Re_DaySchedule.java
+++ b/src/main/java/com/whatachad/app/model/domain/Re_DaySchedule.java
@@ -1,5 +1,6 @@
 package com.whatachad.app.model.domain;
 
+import com.whatachad.app.model.dto.Re_DayScheduleDto;
 import com.whatachad.app.type.Workcheck;
 import jakarta.persistence.*;
 import lombok.*;
@@ -32,6 +33,17 @@ public class Re_DaySchedule {
 
     @OneToMany(mappedBy = "daySchedule")
     private List<Re_Account> accounts = new ArrayList<>();
+
+    public static Re_DaySchedule create(Re_DayScheduleDto dto) {
+        return Re_DaySchedule.builder()
+                .date(dto.getDate())
+                .build();
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.totalDayworkStatus = Workcheck.NOT_COMPLETE;
+    }
 
     /* 연관관계 편의 메소드 */
     public void addSchedule(Re_Schedule schedule) {

--- a/src/main/java/com/whatachad/app/model/domain/Re_Daywork.java
+++ b/src/main/java/com/whatachad/app/model/domain/Re_Daywork.java
@@ -32,4 +32,10 @@ public class Re_Daywork extends BaseTime{
     private Integer hour;
 
     private Integer minute;
+
+    /* 연관관계 편의 메소드 */
+    public void addDaySchedule(Re_DaySchedule daySchedule) {
+        this.daySchedule = daySchedule;
+        daySchedule.getDayworks().add(this);
+    }
 }

--- a/src/main/java/com/whatachad/app/model/domain/Re_Daywork.java
+++ b/src/main/java/com/whatachad/app/model/domain/Re_Daywork.java
@@ -43,12 +43,20 @@ public class Re_Daywork extends BaseTime{
                 .build();
     }
 
+    public void updateDaywork(Re_DayworkDto dto) {
+        this.title = dto.getTitle();
+        this.priority = dto.getPriority();
+        this.status = dto.getStatus();
+        this.hour = dto.getHour();
+        this.minute = dto.getMinute();
+    }
+
     @PrePersist
     public void prePersist() {
         this.status = Workcheck.NOT_COMPLETE;
     }
-
     /* 연관관계 편의 메소드 */
+
     public void addDaySchedule(Re_DaySchedule daySchedule) {
         this.daySchedule = daySchedule;
         daySchedule.getDayworks().add(this);

--- a/src/main/java/com/whatachad/app/model/domain/Re_Daywork.java
+++ b/src/main/java/com/whatachad/app/model/domain/Re_Daywork.java
@@ -1,5 +1,6 @@
 package com.whatachad.app.model.domain;
 
+import com.whatachad.app.model.dto.Re_DayworkDto;
 import com.whatachad.app.type.DayworkPriority;
 import com.whatachad.app.type.Workcheck;
 import jakarta.persistence.*;
@@ -32,6 +33,20 @@ public class Re_Daywork extends BaseTime{
     private Integer hour;
 
     private Integer minute;
+
+    public static Re_Daywork create(Re_DayworkDto dto) {
+        return Re_Daywork.builder()
+                .title(dto.getTitle())
+                .priority(dto.getPriority())
+                .hour(dto.getHour())
+                .minute(dto.getMinute())
+                .build();
+    }
+
+    @PrePersist
+    public void prePersist() {
+        this.status = Workcheck.NOT_COMPLETE;
+    }
 
     /* 연관관계 편의 메소드 */
     public void addDaySchedule(Re_DaySchedule daySchedule) {

--- a/src/main/java/com/whatachad/app/model/domain/Re_Daywork.java
+++ b/src/main/java/com/whatachad/app/model/domain/Re_Daywork.java
@@ -1,0 +1,35 @@
+package com.whatachad.app.model.domain;
+
+import com.whatachad.app.type.DayworkPriority;
+import com.whatachad.app.type.Workcheck;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.validator.constraints.UniqueElements;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Re_Daywork extends BaseTime{
+
+    @Id @GeneratedValue
+    @Column(name = "DAYWORK_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "DAYSCHEDULE_ID")
+    private Re_DaySchedule daySchedule;
+
+    private String title;
+
+    @Enumerated(EnumType.STRING)
+    private DayworkPriority priority;
+
+    @Enumerated(EnumType.STRING)
+    private Workcheck status;
+
+    private Integer hour;
+
+    private Integer minute;
+}

--- a/src/main/java/com/whatachad/app/model/domain/Re_Schedule.java
+++ b/src/main/java/com/whatachad/app/model/domain/Re_Schedule.java
@@ -1,5 +1,6 @@
 package com.whatachad.app.model.domain;
 
+import com.whatachad.app.model.dto.Re_ScheduleDto;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -29,4 +30,18 @@ public class Re_Schedule {
 
     @OneToMany(mappedBy = "schedule")
     List<Re_DaySchedule> days = new ArrayList<>();
+
+    @PrePersist
+    public void prePersist(){
+        this.budget = this.budget == null ? 0 : this.budget;
+    }
+
+    public static Re_Schedule create(Re_ScheduleDto dto, User user) {
+        return Re_Schedule.builder()
+                .user(user)
+                .year(dto.getYear())
+                .month(dto.getMonth())
+                .budget(dto.getBudget())
+                .build();
+    }
 }

--- a/src/main/java/com/whatachad/app/model/domain/Re_Schedule.java
+++ b/src/main/java/com/whatachad/app/model/domain/Re_Schedule.java
@@ -1,0 +1,26 @@
+package com.whatachad.app.model.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Re_Schedule {
+
+    @Id @GeneratedValue
+    @Column(name = "SCHEDULE_ID")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "USER_ID")
+    private  User user;
+
+    private Integer year;
+
+    private Integer month;
+
+    private Integer budget;
+}

--- a/src/main/java/com/whatachad/app/model/domain/Re_Schedule.java
+++ b/src/main/java/com/whatachad/app/model/domain/Re_Schedule.java
@@ -3,6 +3,9 @@ package com.whatachad.app.model.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Getter
 @Builder
 @NoArgsConstructor
@@ -23,4 +26,7 @@ public class Re_Schedule {
     private Integer month;
 
     private Integer budget;
+
+    @OneToMany(mappedBy = "schedule")
+    List<Re_DaySchedule> days = new ArrayList<>();
 }

--- a/src/main/java/com/whatachad/app/model/dto/Re_DayScheduleDto.java
+++ b/src/main/java/com/whatachad/app/model/dto/Re_DayScheduleDto.java
@@ -1,0 +1,15 @@
+package com.whatachad.app.model.dto;
+
+import com.whatachad.app.type.Workcheck;
+import lombok.*;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Re_DayScheduleDto {
+
+    private Long id;
+    private Integer date;
+    private Workcheck totalDayworkStatus;
+}

--- a/src/main/java/com/whatachad/app/model/dto/Re_DayworkDto.java
+++ b/src/main/java/com/whatachad/app/model/dto/Re_DayworkDto.java
@@ -1,0 +1,25 @@
+package com.whatachad.app.model.dto;
+
+
+import com.whatachad.app.type.DayworkPriority;
+import com.whatachad.app.type.Workcheck;
+import lombok.*;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Re_DayworkDto {
+
+    private Long id;
+
+    private String title;
+
+    private DayworkPriority priority;
+
+    private Workcheck status;
+
+    private Integer hour;
+
+    private Integer minute;
+}

--- a/src/main/java/com/whatachad/app/model/dto/Re_ScheduleDto.java
+++ b/src/main/java/com/whatachad/app/model/dto/Re_ScheduleDto.java
@@ -1,0 +1,15 @@
+package com.whatachad.app.model.dto;
+
+import lombok.*;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Re_ScheduleDto {
+
+    private Long id;
+    private Integer year;
+    private Integer month;
+    private Integer budget;
+}

--- a/src/main/java/com/whatachad/app/model/request/Re_CreateDayworkRequestDto.java
+++ b/src/main/java/com/whatachad/app/model/request/Re_CreateDayworkRequestDto.java
@@ -1,0 +1,23 @@
+package com.whatachad.app.model.request;
+
+import com.whatachad.app.type.DayworkPriority;
+import com.whatachad.app.type.Workcheck;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Re_CreateDayworkRequestDto {
+
+    @NotNull
+    private String title;
+
+    @NotNull
+    private DayworkPriority priority;
+
+    private Integer hour;
+
+    private Integer minute;
+}

--- a/src/main/java/com/whatachad/app/model/request/Re_UpdateDayworkRequestDto.java
+++ b/src/main/java/com/whatachad/app/model/request/Re_UpdateDayworkRequestDto.java
@@ -1,0 +1,22 @@
+package com.whatachad.app.model.request;
+
+import com.whatachad.app.type.DayworkPriority;
+import com.whatachad.app.type.Workcheck;
+import lombok.*;
+
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Re_UpdateDayworkRequestDto {
+
+    private String title;
+
+    private DayworkPriority priority;
+
+    private Workcheck status;
+
+    private Integer hour;
+
+    private Integer minute;
+}

--- a/src/main/java/com/whatachad/app/model/response/Re_CreateDayworkResponseDto.java
+++ b/src/main/java/com/whatachad/app/model/response/Re_CreateDayworkResponseDto.java
@@ -1,0 +1,20 @@
+package com.whatachad.app.model.response;
+
+import com.whatachad.app.type.DayworkPriority;
+import com.whatachad.app.type.Workcheck;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Builder
+@Getter
+@AllArgsConstructor
+public class Re_CreateDayworkResponseDto {
+    private Long id;
+    private String title;
+    private DayworkPriority priority;
+    private Workcheck status;
+    private Integer hour;
+    private Integer minute;
+}

--- a/src/main/java/com/whatachad/app/model/response/Re_UpdateDayworkResponseDto.java
+++ b/src/main/java/com/whatachad/app/model/response/Re_UpdateDayworkResponseDto.java
@@ -1,0 +1,24 @@
+package com.whatachad.app.model.response;
+
+import com.whatachad.app.type.DayworkPriority;
+import com.whatachad.app.type.Workcheck;
+import lombok.*;
+
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+@Getter
+public class Re_UpdateDayworkResponseDto {
+
+    private Long id;
+
+    private String title;
+
+    private DayworkPriority priority;
+
+    private Workcheck status;
+
+    private Integer hour;
+
+    private Integer minute;
+}

--- a/src/main/java/com/whatachad/app/repository/Re_DayScheduleRepository.java
+++ b/src/main/java/com/whatachad/app/repository/Re_DayScheduleRepository.java
@@ -1,0 +1,16 @@
+package com.whatachad.app.repository;
+
+import com.whatachad.app.model.domain.Re_DaySchedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface Re_DayScheduleRepository extends JpaRepository<Re_DaySchedule, Long> {
+    // todo: Re_이름 삭제한 뒤 @Query 삭제하기
+    @Query("select d from Re_DaySchedule d where d.date = :date and d.schedule.id = :schedule_id")
+    Optional<Re_DaySchedule> findBydateAndSchedule_Id(@Param(value = "date") Integer date, @Param(value = "schedule_id") Long scheduleId);
+}

--- a/src/main/java/com/whatachad/app/repository/Re_DayworkRepository.java
+++ b/src/main/java/com/whatachad/app/repository/Re_DayworkRepository.java
@@ -1,0 +1,10 @@
+package com.whatachad.app.repository;
+
+import com.whatachad.app.model.domain.Re_Daywork;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface Re_DayworkRepository extends JpaRepository<Re_Daywork, Long> {
+
+}

--- a/src/main/java/com/whatachad/app/repository/Re_ScheduleRepository.java
+++ b/src/main/java/com/whatachad/app/repository/Re_ScheduleRepository.java
@@ -1,0 +1,15 @@
+package com.whatachad.app.repository;
+
+import com.whatachad.app.model.domain.Re_Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface Re_ScheduleRepository extends JpaRepository<Re_Schedule, Long> {
+
+    Optional<Re_Schedule> findByYearAndMonthAndUser_Id(@Param(value = "year") Integer year, @Param(value = "month") Integer month, @Param(value = "userId") String userId);
+}

--- a/src/main/java/com/whatachad/app/service/Re_DayScheduleMapperService.java
+++ b/src/main/java/com/whatachad/app/service/Re_DayScheduleMapperService.java
@@ -1,0 +1,16 @@
+package com.whatachad.app.service;
+
+import com.whatachad.app.model.dto.Re_DayScheduleDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class Re_DayScheduleMapperService {
+
+    public Re_DayScheduleDto toDayScheduleDto(Integer date) {
+        return Re_DayScheduleDto.builder()
+                .date(date)
+                .build();
+    }
+}

--- a/src/main/java/com/whatachad/app/service/Re_DayScheduleService.java
+++ b/src/main/java/com/whatachad/app/service/Re_DayScheduleService.java
@@ -1,0 +1,44 @@
+package com.whatachad.app.service;
+
+import com.whatachad.app.common.BError;
+import com.whatachad.app.common.CommonException;
+import com.whatachad.app.model.domain.Re_DaySchedule;
+import com.whatachad.app.model.domain.Re_Daywork;
+import com.whatachad.app.model.dto.Re_DayScheduleDto;
+import com.whatachad.app.model.dto.Re_DayworkDto;
+import com.whatachad.app.repository.Re_DayScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class Re_DayScheduleService {
+
+    private final Re_DayScheduleRepository dayScheduleRepository;
+    private final Re_DayworkService dayworkService;
+
+    @Transactional
+    public Re_DaySchedule getOrCreateDaySchedule(Re_DayScheduleDto dayScheduleDto, Long scheduleId) {
+        Optional<Re_DaySchedule> findDaySchedule = dayScheduleRepository.findBydateAndSchedule_Id(dayScheduleDto.getDate(), scheduleId);
+
+        if (findDaySchedule.isEmpty()) {
+            return dayScheduleRepository.save(Re_DaySchedule.create(dayScheduleDto));
+        }
+        return findDaySchedule.get();
+    }
+
+    @Transactional
+    public Re_Daywork createDaywork(Re_DayworkDto dayworkDto, Long dayScheduleId) {
+        Re_DaySchedule daySchedule = dayScheduleRepository.findById(dayScheduleId)
+                .orElseThrow(() -> new CommonException(BError.NOT_EXIST, "daySchedule"));
+
+        Re_Daywork daywork = dayworkService.createDaywork(dayworkDto);
+        daywork.addDaySchedule(daySchedule);
+        return daywork;
+    }
+}

--- a/src/main/java/com/whatachad/app/service/Re_DayworkMapperService.java
+++ b/src/main/java/com/whatachad/app/service/Re_DayworkMapperService.java
@@ -1,0 +1,32 @@
+package com.whatachad.app.service;
+
+import com.whatachad.app.model.domain.Re_Daywork;
+import com.whatachad.app.model.dto.Re_DayworkDto;
+import com.whatachad.app.model.request.Re_CreateDayworkRequestDto;
+import com.whatachad.app.model.response.Re_CreateDayworkResponseDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class Re_DayworkMapperService {
+    public Re_DayworkDto toDayworkDto(Re_CreateDayworkRequestDto requestDto) {
+        return Re_DayworkDto.builder()
+                .title(requestDto.getTitle())
+                .priority(requestDto.getPriority())
+                .hour(requestDto.getHour())
+                .minute(requestDto.getMinute())
+                .build();
+    }
+
+    public Re_CreateDayworkResponseDto toCreateResponseDto(Re_Daywork daywork) {
+        return Re_CreateDayworkResponseDto.builder()
+                .id(daywork.getId())
+                .title(daywork.getTitle())
+                .priority(daywork.getPriority())
+                .status(daywork.getStatus())
+                .hour(daywork.getHour())
+                .minute(daywork.getMinute())
+                .build();
+    }
+}

--- a/src/main/java/com/whatachad/app/service/Re_DayworkMapperService.java
+++ b/src/main/java/com/whatachad/app/service/Re_DayworkMapperService.java
@@ -3,7 +3,9 @@ package com.whatachad.app.service;
 import com.whatachad.app.model.domain.Re_Daywork;
 import com.whatachad.app.model.dto.Re_DayworkDto;
 import com.whatachad.app.model.request.Re_CreateDayworkRequestDto;
+import com.whatachad.app.model.request.Re_UpdateDayworkRequestDto;
 import com.whatachad.app.model.response.Re_CreateDayworkResponseDto;
+import com.whatachad.app.model.response.Re_UpdateDayworkResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +23,27 @@ public class Re_DayworkMapperService {
 
     public Re_CreateDayworkResponseDto toCreateResponseDto(Re_Daywork daywork) {
         return Re_CreateDayworkResponseDto.builder()
+                .id(daywork.getId())
+                .title(daywork.getTitle())
+                .priority(daywork.getPriority())
+                .status(daywork.getStatus())
+                .hour(daywork.getHour())
+                .minute(daywork.getMinute())
+                .build();
+    }
+
+    public Re_DayworkDto toDayworkDto(Re_UpdateDayworkRequestDto requestDto) {
+        return Re_DayworkDto.builder()
+                .title(requestDto.getTitle())
+                .priority(requestDto.getPriority())
+                .status(requestDto.getStatus())
+                .hour(requestDto.getHour())
+                .minute(requestDto.getMinute())
+                .build();
+    }
+
+    public Re_UpdateDayworkResponseDto toUpdateResponseDto(Re_Daywork daywork) {
+        return Re_UpdateDayworkResponseDto.builder()
                 .id(daywork.getId())
                 .title(daywork.getTitle())
                 .priority(daywork.getPriority())

--- a/src/main/java/com/whatachad/app/service/Re_DayworkService.java
+++ b/src/main/java/com/whatachad/app/service/Re_DayworkService.java
@@ -1,0 +1,22 @@
+package com.whatachad.app.service;
+
+import com.whatachad.app.model.domain.Re_Daywork;
+import com.whatachad.app.model.dto.Re_DayworkDto;
+import com.whatachad.app.repository.Re_DayworkRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class Re_DayworkService {
+
+    private final Re_DayworkRepository dayworkRepository;
+
+    @Transactional
+    public Re_Daywork createDaywork(Re_DayworkDto dayworkDto) {
+        return dayworkRepository.save(Re_Daywork.create(dayworkDto));
+    }
+}

--- a/src/main/java/com/whatachad/app/service/Re_DayworkService.java
+++ b/src/main/java/com/whatachad/app/service/Re_DayworkService.java
@@ -24,11 +24,15 @@ public class Re_DayworkService {
 
     @Transactional
     public Re_Daywork updateDaywork(Re_DayworkDto dayworkDto, Long dayworkId) {
-        log.info("dayworkDto = {}", dayworkDto.getStatus());
         Re_Daywork findDaywork = dayworkRepository.findById(dayworkId)
                 .orElseThrow(() -> new CommonException(BError.NOT_EXIST, "daywork"));
         findDaywork.updateDaywork(dayworkDto);
 
         return findDaywork;
+    }
+
+    @Transactional
+    public void deleteDaywork(Long dayworkId) {
+        dayworkRepository.deleteById(dayworkId);
     }
 }

--- a/src/main/java/com/whatachad/app/service/Re_DayworkService.java
+++ b/src/main/java/com/whatachad/app/service/Re_DayworkService.java
@@ -1,5 +1,7 @@
 package com.whatachad.app.service;
 
+import com.whatachad.app.common.BError;
+import com.whatachad.app.common.CommonException;
 import com.whatachad.app.model.domain.Re_Daywork;
 import com.whatachad.app.model.dto.Re_DayworkDto;
 import com.whatachad.app.repository.Re_DayworkRepository;
@@ -18,5 +20,15 @@ public class Re_DayworkService {
     @Transactional
     public Re_Daywork createDaywork(Re_DayworkDto dayworkDto) {
         return dayworkRepository.save(Re_Daywork.create(dayworkDto));
+    }
+
+    @Transactional
+    public Re_Daywork updateDaywork(Re_DayworkDto dayworkDto, Long dayworkId) {
+        log.info("dayworkDto = {}", dayworkDto.getStatus());
+        Re_Daywork findDaywork = dayworkRepository.findById(dayworkId)
+                .orElseThrow(() -> new CommonException(BError.NOT_EXIST, "daywork"));
+        findDaywork.updateDaywork(dayworkDto);
+
+        return findDaywork;
     }
 }

--- a/src/main/java/com/whatachad/app/service/Re_ScheduleMapperService.java
+++ b/src/main/java/com/whatachad/app/service/Re_ScheduleMapperService.java
@@ -1,0 +1,20 @@
+package com.whatachad.app.service;
+
+import com.whatachad.app.model.dto.Re_ScheduleDto;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class Re_ScheduleMapperService {
+
+    public Re_ScheduleDto toScheduleDto(String yearAndMonth) {
+        String year = yearAndMonth.substring(0, 4);
+        String month = yearAndMonth.substring(4);
+
+        return Re_ScheduleDto.builder()
+                .year(Integer.valueOf(year))
+                .month(Integer.valueOf(month))
+                .build();
+    }
+}

--- a/src/main/java/com/whatachad/app/service/Re_ScheduleService.java
+++ b/src/main/java/com/whatachad/app/service/Re_ScheduleService.java
@@ -1,0 +1,62 @@
+package com.whatachad.app.service;
+
+import com.whatachad.app.common.BError;
+import com.whatachad.app.common.CommonException;
+import com.whatachad.app.model.domain.Re_DaySchedule;
+import com.whatachad.app.model.domain.Re_Schedule;
+import com.whatachad.app.model.domain.User;
+import com.whatachad.app.model.dto.Re_DayScheduleDto;
+import com.whatachad.app.model.dto.Re_ScheduleDto;
+import com.whatachad.app.repository.Re_ScheduleRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class Re_ScheduleService {
+
+    private final UserService userService;
+    private final Re_ScheduleRepository scheduleRepository;
+    private final Re_DayScheduleService dayScheduleService;
+
+    @Transactional
+    public Re_Schedule getOrCreateSchedule(Re_ScheduleDto scheduleDto) {
+//        Re_Schedule findSchedule = scheduleRepository.findByYearAndMonthAndUser_Id(
+//                        scheduleDto.getYear(),
+//                        scheduleDto.getMonth(),
+//                        getLoginUser().getId())
+//        .orElse(scheduleRepository.save(Re_Schedule.create(scheduleDto, getLoginUser())));
+        Optional<Re_Schedule> findSchedule = scheduleRepository.findByYearAndMonthAndUser_Id(
+                        scheduleDto.getYear(),
+                        scheduleDto.getMonth(),
+                        getLoginUser().getId());
+
+        if (findSchedule.isEmpty()) {
+            return scheduleRepository.save(Re_Schedule.create(scheduleDto, getLoginUser()));
+        }
+        return findSchedule.get();
+    }
+
+    @Transactional
+    public Re_DaySchedule getDaySchedule(Re_DayScheduleDto dayScheduleDto, Long scheduleId) {
+        Re_Schedule schedule = scheduleRepository.findById(scheduleId)
+                .orElseThrow(() -> new CommonException(BError.NOT_EXIST, "daySchedule"));
+        Re_DaySchedule daySchedule = dayScheduleService.getOrCreateDaySchedule(dayScheduleDto, scheduleId);
+
+        daySchedule.addSchedule(schedule);
+        return daySchedule;
+    }
+
+    /**
+     *  private method
+     * */
+    private User getLoginUser() {
+        String loginUserId = userService.getLoginUserId();
+        return userService.getUser(loginUserId);
+    }
+}

--- a/src/test/java/com/whatachad/app/service/Re_ScheduleServiceTest.java
+++ b/src/test/java/com/whatachad/app/service/Re_ScheduleServiceTest.java
@@ -1,0 +1,77 @@
+package com.whatachad.app.service;
+
+import com.whatachad.app.model.domain.Re_Schedule;
+import com.whatachad.app.model.dto.Re_ScheduleDto;
+import com.whatachad.app.model.request.UserLoginRequestDto;
+import com.whatachad.app.model.response.UserTokenResponseDto;
+import io.jsonwebtoken.Claims;
+import jakarta.persistence.EntityManager;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.orm.hibernate5.SessionFactoryUtils;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+public class Re_ScheduleServiceTest {
+    @Autowired private Re_ScheduleService scheduleService;
+    @Autowired private TokenService tokenService;
+
+    Re_Schedule schedule;
+
+    @BeforeEach
+    void init() throws Exception{
+        authorize();
+        Integer year = 2023;
+        Integer month = 4;
+        Re_ScheduleDto dto = Re_ScheduleDto.builder()
+                .year(year)
+                .month(month)
+                .build();
+        schedule = scheduleService.getOrCreateSchedule(dto);
+    }
+
+    @Test
+    public void getOrCreateSchedule() {
+        Integer year = 2023;
+        Integer month = 4;
+        Re_ScheduleDto dto = Re_ScheduleDto.builder()
+                .year(year)
+                .month(month)
+                .build();
+        Re_Schedule schedule = scheduleService.getOrCreateSchedule(dto);
+        assertEquals(schedule.getYear(), year);
+        assertEquals(schedule.getMonth(), month);
+
+        Re_Schedule schedule2 = scheduleService.getOrCreateSchedule(dto);
+        assertEquals(schedule.getId(), schedule2.getId());
+    }
+
+
+    private void authorize() {
+        UserLoginRequestDto loginDto = UserLoginRequestDto.builder()
+                .id("admin")
+                .password("admin")
+                .build();
+        UserTokenResponseDto token = UserTokenResponseDto.builder()
+                .accessToken(tokenService.genAccessToken(loginDto.getId()))
+                .refreshToken(tokenService.genRefreshToken(loginDto.getId()))
+                .build();
+        Claims claims = tokenService.validateToken(token.getAccessToken());
+        List<String> authorities = (List) claims.get("authorities");
+        UsernamePasswordAuthenticationToken auth = new UsernamePasswordAuthenticationToken(claims.getSubject(), null,
+                authorities.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList()));
+        SecurityContextHolder.getContext().setAuthentication(auth);
+    }
+}


### PR DESCRIPTION
- 외래키 세팅은 부모 객체의 Service에서 진행.
 	=> 부모 객체의 Service에서 해당 객체의 create메소드 부르도록 설계
- 이전에 repository에서 findbyXXX로 외래키의 멤버 필드에 접근하는 방법 없다고 했는데 다시 찾아보니까 나오더라고요ㅎㅎ그래서 적용해봤습니다.
- entity 클래스 이름을 Re_DaySchedule라고 하니까 DB테이블 명은 re_day_schedule이 되더라고요. Re 뺄 때 Dayschedule로 고쳐야할 듯 합니다.